### PR TITLE
remember settings

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -1,6 +1,19 @@
+import json
 import time
 
 
 def clear(streamlit_object, seconds):
     time.sleep(seconds)
     streamlit_object.empty()
+
+
+def get_config(config_file):
+    try:
+        return json.load(open(config_file))
+    except FileNotFoundError:
+        return {}
+
+
+def put_config(config_file, config):
+    with open(config_file, "w") as f:
+        f.write(json.dumps(config))


### PR DESCRIPTION
Closes #37 

This PR makes it so that the app remembers the last dates used and whether or not `show sql` is checked upon app restart or refresh.

It does this by persisting a `config.json` in the user's data dir that is read on load and updated as the user interacts with the UI.