### PR TITLE
Updates CI to cache dependencies 

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,18 +1,17 @@
-name: tests
+name: master-tests
 
-on: [push]
-
-concurrency:
-  group: test-${{ github.ref }}
-  cancel-in-progress: true
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   build:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        python-version: ["3.10"]
-        os: ['ubuntu-latest']
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
     steps:
     - uses: actions/checkout@v3
     - name: Set up ${{ matrix.python-version }}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -2,6 +2,10 @@ name: tests
 
 on: [push]
 
+concurrency:
+  group: test-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ${{matrix.os}}
@@ -12,18 +16,41 @@ jobs:
         python-version: ["3.10"]
         os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
+      id: py
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+    - uses: actions/cache@v3
+      id: cache
+      with:
+        path: venv
+        key: ${{ runner.os }}-${{ steps.py.outputs.python-version }}-${{ hashFiles('requirements.txt') }}
+    - name: Install dependencies unix
+      if: |
+        steps.cache.outputs.cache-hit != 'true'
+        &&  matrix.os != 'windows-latest'
       run: |
+        python -m venv venv && source venv/bin/activate
         pip install --upgrade pip
         pip install -r requirements.txt
-    - name: Test with nose on ubuntu and macOS
-      run: pytest .
+    - name: Install dependencies windows
+      if: |
+        steps.cache.outputs.cache-hit != 'true'
+        &&  matrix.os == 'windows-latest'
+      run: |
+        python -m venv venv
+        venv\Scripts\activate
+        pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Test on ubuntu and macOS
+      run: |
+        source venv/bin/activate
+        pytest .
       if: matrix.os != 'windows-latest'
     - name: Test with nose on ubuntu and macOS
-      run: pytest . -m "not fails_on_windows"
+      run: |
+        venv\Scripts\activate
+        pytest . -m "not fails_on_windows"
       if: matrix.os == 'windows-latest'

--- a/README.md
+++ b/README.md
@@ -88,5 +88,3 @@ pip install -r requirements.txt
 The benefit of this approach is that we can ensure all environments (dev / ci / etc)
 have the same exact same versions of each dependency installed, while making it easy to
 add and update top level requirements.
-
-


### PR DESCRIPTION
Closes #39 


This PR caches the requirements in a virtual environment and only re-installs when something changes. This speeds up the testing ci step a lot.