### PR TITLE
Extended Chase/Amex support, analysis module, and categorization

### DIFF
--- a/src/analysis.py
+++ b/src/analysis.py
@@ -11,6 +11,7 @@ import pandas as pd
 
 def normalize_merchant(description_series: pd.Series, max_words: int = 4) -> pd.Series:
     """Normalize description to a stable merchant key for grouping."""
+
     def _norm(s):
         if pd.isna(s) or not isinstance(s, str):
             return ""
@@ -59,14 +60,16 @@ def _merchant_groups_with_schedule(
         if abs(mean_interval - 30) <= interval_tolerance_days or (
             mean_interval >= 25 and mean_interval <= 35
         ):
-            out.append({
-                "merchant": merchant,
-                "transaction_count": len(grp),
-                "mean_interval_days": round(mean_interval, 1),
-                "last_date": dates.max().isoformat()[:10],
-                "total_amount": round(grp["amount"].sum(), 2),
-                "mean_amount": round(grp["amount"].mean(), 2),
-            })
+            out.append(
+                {
+                    "merchant": merchant,
+                    "transaction_count": len(grp),
+                    "mean_interval_days": round(mean_interval, 1),
+                    "last_date": dates.max().isoformat()[:10],
+                    "total_amount": round(grp["amount"].sum(), 2),
+                    "mean_amount": round(grp["amount"].mean(), 2),
+                }
+            )
     if not out:
         return pd.DataFrame()
     return pd.DataFrame(out)
@@ -126,7 +129,9 @@ def identify_frequent_merchants(
         return pd.DataFrame()
 
     if not exclude_recurring:
-        return scheduled.sort_values("total_amount", ascending=False).reset_index(drop=True)
+        return scheduled.sort_values("total_amount", ascending=False).reset_index(
+            drop=True
+        )
 
     df = df.copy()
     if normalize_description:
@@ -178,12 +183,16 @@ def flag_recurring_in_catchall(
     subset["merchant"] = normalize_merchant(subset["description"])
     subset = subset[subset["merchant"] != ""]
 
-    grp = subset.groupby(["merchant", "category"]).agg(
-        transaction_count=("amount", "count"),
-        total_amount=("amount", "sum"),
-        date_min=("date", "min"),
-        date_max=("date", "max"),
-    ).reset_index()
+    grp = (
+        subset.groupby(["merchant", "category"])
+        .agg(
+            transaction_count=("amount", "count"),
+            total_amount=("amount", "sum"),
+            date_min=("date", "min"),
+            date_max=("date", "max"),
+        )
+        .reset_index()
+    )
 
     grp = grp[grp["transaction_count"] >= min_occurrences]
     grp["total_amount"] = grp["total_amount"].round(2)
@@ -251,12 +260,14 @@ def monthly_outliers(
         for _, row in grp.iterrows():
             amt = row["period_amount"]
             if amt < lo or amt > hi:
-                out.append({
-                    "period": row["period"],
-                    name_col: key,
-                    "period_amount": round(amt, 2),
-                    "is_high_outlier": amt > hi,
-                })
+                out.append(
+                    {
+                        "period": row["period"],
+                        name_col: key,
+                        "period_amount": round(amt, 2),
+                        "is_high_outlier": amt > hi,
+                    }
+                )
 
     if not out:
         return pd.DataFrame()

--- a/src/analysis.py
+++ b/src/analysis.py
@@ -17,8 +17,8 @@ def normalize_merchant(description_series: pd.Series, max_words: int = 4) -> pd.
             return ""
         s = s.lower().strip()
         s = re.sub(r"\s+", " ", s)
-        # Drop trailing alphanumeric IDs (e.g. "NETFLIX 12345" -> "netflix")
-        s = re.sub(r"\s*[\dA-Za-z]{6,}\s*$", "", s)
+        # Drop trailing ID-like tokens (start with digit, 6+ chars); avoid stripping words like "foods"
+        s = re.sub(r"\s+\d[\dA-Za-z]{5,}\s*$", "", s)
         # Drop trailing space + digits so "netflix 1" / "netflix 2" -> "netflix"
         s = re.sub(r"\s+\d+$", "", s)
         # Drop trailing space + short alphanumeric so "coffee a" / "coffee b" -> "coffee"
@@ -272,5 +272,4 @@ def monthly_outliers(
     if not out:
         return pd.DataFrame()
     result = pd.DataFrame(out)
-    result = result.sort_values(["period", "period_amount"], ascending=[True, False])
-    return result.rename(columns={"period_amount": "monthly_amount", "period": "month"})
+    return result.sort_values(["period", "period_amount"], ascending=[True, False])

--- a/src/analysis.py
+++ b/src/analysis.py
@@ -1,0 +1,265 @@
+"""
+Analysis helpers for expense data: recurring expenses, high dining,
+recurring in catchall categories, and monthly outliers.
+"""
+
+import re
+from typing import Sequence
+
+import pandas as pd
+
+
+def normalize_merchant(description_series: pd.Series, max_words: int = 4) -> pd.Series:
+    """Normalize description to a stable merchant key for grouping."""
+    def _norm(s):
+        if pd.isna(s) or not isinstance(s, str):
+            return ""
+        s = s.lower().strip()
+        s = re.sub(r"\s+", " ", s)
+        # Drop trailing alphanumeric IDs (e.g. "NETFLIX 12345" -> "netflix")
+        s = re.sub(r"\s*[\dA-Za-z]{6,}\s*$", "", s)
+        # Drop trailing space + digits so "netflix 1" / "netflix 2" -> "netflix"
+        s = re.sub(r"\s+\d+$", "", s)
+        # Drop trailing space + short alphanumeric so "coffee a" / "coffee b" -> "coffee"
+        s = re.sub(r"\s+[a-z0-9]+$", "", s)
+        words = s.split()[:max_words]
+        return " ".join(words).strip() or s[:50]
+
+    return description_series.apply(_norm)
+
+
+def _merchant_groups_with_schedule(
+    df: pd.DataFrame,
+    min_occurrences: int,
+    interval_tolerance_days: int,
+    normalize_description: bool,
+) -> pd.DataFrame:
+    """Group by merchant, keep only those with roughly monthly schedule. No amount constraint."""
+    if df.empty or "date" not in df.columns or "description" not in df.columns:
+        return pd.DataFrame()
+
+    df = df.copy()
+    df["date"] = pd.to_datetime(df["date"])
+    df = df.sort_values("date")
+    if normalize_description:
+        df["merchant"] = normalize_merchant(df["description"])
+    else:
+        df["merchant"] = df["description"].fillna("").astype(str)
+    df = df[df["amount"] > 0]
+
+    out = []
+    for merchant, grp in df.groupby("merchant"):
+        if merchant == "" or len(grp) < min_occurrences:
+            continue
+        dates = grp["date"].sort_values()
+        deltas = dates.diff().dt.days.dropna()
+        if deltas.empty:
+            continue
+        mean_interval = deltas.mean()
+        if abs(mean_interval - 30) <= interval_tolerance_days or (
+            mean_interval >= 25 and mean_interval <= 35
+        ):
+            out.append({
+                "merchant": merchant,
+                "transaction_count": len(grp),
+                "mean_interval_days": round(mean_interval, 1),
+                "last_date": dates.max().isoformat()[:10],
+                "total_amount": round(grp["amount"].sum(), 2),
+                "mean_amount": round(grp["amount"].mean(), 2),
+            })
+    if not out:
+        return pd.DataFrame()
+    return pd.DataFrame(out)
+
+
+def identify_recurring(
+    df: pd.DataFrame,
+    min_occurrences: int = 3,
+    interval_tolerance_days: int = 7,
+    normalize_description: bool = True,
+    same_amount_ratio_threshold: float = 0.8,
+) -> pd.DataFrame:
+    """Recurring expenses / subscriptions: roughly monthly and same amount in >80% of cases."""
+    scheduled = _merchant_groups_with_schedule(
+        df, min_occurrences, interval_tolerance_days, normalize_description
+    )
+    if scheduled.empty:
+        return pd.DataFrame()
+
+    df = df.copy()
+    df["date"] = pd.to_datetime(df["date"])
+    if normalize_description:
+        df["merchant"] = normalize_merchant(df["description"])
+    else:
+        df["merchant"] = df["description"].fillna("").astype(str)
+    df = df[df["amount"] > 0]
+
+    out = []
+    for _, row in scheduled.iterrows():
+        merchant = row["merchant"]
+        grp = df[df["merchant"] == merchant]
+        amounts = grp["amount"].round(2)
+        # Most common amount (mode)
+        mode_count = amounts.value_counts().iloc[0]
+        if mode_count / len(grp) >= same_amount_ratio_threshold:
+            out.append(row)
+
+    if not out:
+        return pd.DataFrame()
+    result = pd.DataFrame(out)
+    return result.sort_values("total_amount", ascending=False).reset_index(drop=True)
+
+
+def identify_frequent_merchants(
+    df: pd.DataFrame,
+    min_occurrences: int = 3,
+    interval_tolerance_days: int = 7,
+    normalize_description: bool = True,
+    exclude_recurring: bool = True,
+    same_amount_ratio_threshold: float = 0.8,
+) -> pd.DataFrame:
+    """Frequent merchants: roughly monthly but varying amounts (not same charge every time)."""
+    scheduled = _merchant_groups_with_schedule(
+        df, min_occurrences, interval_tolerance_days, normalize_description
+    )
+    if scheduled.empty:
+        return pd.DataFrame()
+
+    if not exclude_recurring:
+        return scheduled.sort_values("total_amount", ascending=False).reset_index(drop=True)
+
+    df = df.copy()
+    if normalize_description:
+        df["merchant"] = normalize_merchant(df["description"])
+    else:
+        df["merchant"] = df["description"].fillna("").astype(str)
+    df = df[df["amount"] > 0]
+
+    out = []
+    for _, row in scheduled.iterrows():
+        merchant = row["merchant"]
+        grp = df[df["merchant"] == merchant]
+        amounts = grp["amount"].round(2)
+        mode_count = amounts.value_counts().iloc[0]
+        if mode_count / len(grp) < same_amount_ratio_threshold:
+            out.append(row)
+
+    if not out:
+        return pd.DataFrame()
+    result = pd.DataFrame(out)
+    return result.sort_values("total_amount", ascending=False).reset_index(drop=True)
+
+
+def flag_high_dining(
+    df: pd.DataFrame,
+    category: str = "Dining",
+    threshold: float = 100.0,
+) -> pd.DataFrame:
+    """Flag dining expenses over a threshold (default 100)."""
+    if df.empty or "category" not in df.columns or "amount" not in df.columns:
+        return pd.DataFrame()
+    subset = df[(df["category"] == category) & (df["amount"].abs() > threshold)]
+    return subset[["date", "description", "amount", "category"]].copy()
+
+
+def flag_recurring_in_catchall(
+    df: pd.DataFrame,
+    catchall_categories: Sequence[str] = ("Other", "Transfer"),
+    min_occurrences: int = 2,
+) -> pd.DataFrame:
+    """Flag recurring merchants in catchall categories (Other, Transfer)."""
+    if df.empty or "category" not in df.columns or "description" not in df.columns:
+        return pd.DataFrame()
+
+    subset = df[df["category"].isin(catchall_categories)].copy()
+    if subset.empty:
+        return pd.DataFrame()
+
+    subset["merchant"] = normalize_merchant(subset["description"])
+    subset = subset[subset["merchant"] != ""]
+
+    grp = subset.groupby(["merchant", "category"]).agg(
+        transaction_count=("amount", "count"),
+        total_amount=("amount", "sum"),
+        date_min=("date", "min"),
+        date_max=("date", "max"),
+    ).reset_index()
+
+    grp = grp[grp["transaction_count"] >= min_occurrences]
+    grp["total_amount"] = grp["total_amount"].round(2)
+    return grp.sort_values("total_amount", ascending=False).reset_index(drop=True)
+
+
+def monthly_outliers(
+    df: pd.DataFrame,
+    group_by: str = "category",
+    method: str = "iqr",
+    k: float = 1.5,
+    min_periods: int = 2,
+    freq: str = "M",
+) -> pd.DataFrame:
+    """
+    Identify outliers by time period: by category or by (normalized) merchant.
+    freq: pandas period code for grouping ('M'=month, 'W'=week, 'Y'=year, 'D'=day).
+    method: 'iqr' (Q1 - k*IQR, Q3 + k*IQR) or 'zscore' (|z| > 2).
+    """
+    if df.empty or "date" not in df.columns or "amount" not in df.columns:
+        return pd.DataFrame()
+
+    df = df.copy()
+    df["date"] = pd.to_datetime(df["date"])
+    df["period"] = df["date"].dt.to_period(freq).astype(str)
+    df = df[df["amount"] > 0]
+
+    if group_by == "merchant":
+        df["merchant"] = normalize_merchant(df["description"])
+        group_cols = ["period", "merchant"]
+        name_col = "merchant"
+    else:
+        if "category" not in df.columns:
+            return pd.DataFrame()
+        group_cols = ["period", "category"]
+        name_col = "category"
+
+    agg = (
+        df.groupby(group_cols)["amount"]
+        .sum()
+        .reset_index()
+        .rename(columns={"amount": "period_amount"})
+    )
+
+    n_periods = agg["period"].nunique()
+    if n_periods < min_periods:
+        return pd.DataFrame()
+
+    out = []
+    for key, grp in agg.groupby(name_col):
+        vals = grp["period_amount"]
+        if len(vals) < min_periods:
+            continue
+        if method == "iqr":
+            q1, q3 = vals.quantile(0.25), vals.quantile(0.75)
+            iqr = q3 - q1
+            lo, hi = q1 - k * iqr, q3 + k * iqr
+        else:
+            mean, std = vals.mean(), vals.std()
+            if std == 0:
+                continue
+            lo = mean - 2 * std
+            hi = mean + 2 * std
+
+        for _, row in grp.iterrows():
+            amt = row["period_amount"]
+            if amt < lo or amt > hi:
+                out.append({
+                    "period": row["period"],
+                    name_col: key,
+                    "period_amount": round(amt, 2),
+                    "is_high_outlier": amt > hi,
+                })
+
+    if not out:
+        return pd.DataFrame()
+    result = pd.DataFrame(out)
+    result = result.sort_values(["period", "period_amount"], ascending=[True, False])
+    return result.rename(columns={"period_amount": "monthly_amount", "period": "month"})

--- a/src/card_definitions.json
+++ b/src/card_definitions.json
@@ -141,37 +141,6 @@
       "Type",
       "Balance",
       "Check or Slip #",
-      "Unknown"
-    ],
-    "Posting Date": "date",
-    "Description": "description",
-    "Amount": "amount",
-    "Type": "category"
-  },
-  "chase-bank-7": {
-    "schema": [
-      "Details",
-      "Posting Date",
-      "Description",
-      "Amount",
-      "Type",
-      "Balance",
-      "Check or Slip #"
-    ],
-    "Posting Date": "date",
-    "Description": "description",
-    "Amount": "amount",
-    "Type": "category"
-  },
-  "chase-bank-8": {
-    "schema": [
-      "Details",
-      "Posting Date",
-      "Description",
-      "Amount",
-      "Type",
-      "Balance",
-      "Check or Slip #",
       ""
     ],
     "Posting Date": "date",

--- a/src/card_definitions.json
+++ b/src/card_definitions.json
@@ -18,6 +18,27 @@
     "Amount": "amount",
     "Category": "category"
   },
+  "amex_groceries_ext": {
+    "schema": [
+      "Date",
+      "Description",
+      "Card Member",
+      "Account #",
+      "Amount",
+      "Extended Details",
+      "Appears On Your Statement As",
+      "Address",
+      "City/State",
+      "Zip Code",
+      "Country",
+      "Reference",
+      "Category"
+    ],
+    "Date": "date",
+    "Description": "description",
+    "Amount": "amount",
+    "Category": "category"
+  },
   "svb": {
     "schema": [
       "Date",
@@ -110,6 +131,53 @@
     "Description": "description",
     "Amount": "-amount",
     "Category": "category"
+  },
+  "chase-bank": {
+    "schema": [
+      "Details",
+      "Posting Date",
+      "Description",
+      "Amount",
+      "Type",
+      "Balance",
+      "Check or Slip #",
+      "Unknown"
+    ],
+    "Posting Date": "date",
+    "Description": "description",
+    "Amount": "amount",
+    "Type": "category"
+  },
+  "chase-bank-7": {
+    "schema": [
+      "Details",
+      "Posting Date",
+      "Description",
+      "Amount",
+      "Type",
+      "Balance",
+      "Check or Slip #"
+    ],
+    "Posting Date": "date",
+    "Description": "description",
+    "Amount": "amount",
+    "Type": "category"
+  },
+  "chase-bank-8": {
+    "schema": [
+      "Details",
+      "Posting Date",
+      "Description",
+      "Amount",
+      "Type",
+      "Balance",
+      "Check or Slip #",
+      ""
+    ],
+    "Posting Date": "date",
+    "Description": "description",
+    "Amount": "-amount",
+    "Type": "category"
   },
   "plaid": {
     "schema": [

--- a/src/detect.py
+++ b/src/detect.py
@@ -73,7 +73,9 @@ def save_file_if_valid(file_, data_dir):
             os.replace(tempfilename, os.path.join(upload_dir, file_name))
             return "success", f"{file_name}: {card}"
         else:
-            columns_msg = f" (columns: {info['columns']})" if info and "columns" in info else ""
+            columns_msg = (
+                f" (columns: {info['columns']})" if info and "columns" in info else ""
+            )
             return "failed", f"{file_name}{columns_msg}"
 
 
@@ -84,7 +86,9 @@ def _detect(infile):
     if card:
         click.echo(card)
     else:
-        click.echo(f"No matching card. Columns: {info['columns'] if info else 'unknown'}")
+        click.echo(
+            f"No matching card. Columns: {info['columns'] if info else 'unknown'}"
+        )
 
 
 if __name__ == "__main__":

--- a/src/detect.py
+++ b/src/detect.py
@@ -9,32 +9,45 @@ from common import records_from_file
 
 script_dir = os.path.dirname(os.path.realpath(__file__))
 
-CARD_DEFINITIONS = json.load(open(os.path.join(script_dir, "card_definitions.json")))
-SCHEMALESS_CARD_DEFS = copy.deepcopy(CARD_DEFINITIONS)
-for value in SCHEMALESS_CARD_DEFS.values():
-    value.pop("schema")
+
+def _load_card_definitions():
+    with open(os.path.join(script_dir, "card_definitions.json")) as f:
+        definitions = json.load(f)
+    schemaless = copy.deepcopy(definitions)
+    for value in schemaless.values():
+        value.pop("schema")
+    return definitions, schemaless
+
+
+def get_schemaless_card_defs():
+    """Return schemaless card definitions (for tests and callers that need a def by name)."""
+    _, schemaless = _load_card_definitions()
+    return schemaless
 
 
 def identify_card(record):
     """
-    Looks at a json record and returns the matching card + card_definition
+    Looks at a json record and returns the matching card + card_definition.
 
-    :param record: a json record
-    :return: the matching card name, the card definition (field name mapping)
+    :param record: a json record (dict with column names as keys)
+    :return: (card_name, card_def, info). On match: (card, card_def, None).
+        On no match: (None, None, info) where info is {"columns": list of column names found}.
     """
+    card_definitions, schemaless_card_defs = _load_card_definitions()
     columns = list(record)
     if "source_file" in record:
         columns.remove("source_file")
-    for card, card_def in CARD_DEFINITIONS.items():
+    for card, card_def in card_definitions.items():
         if columns == card_def["schema"]:
-            return card, SCHEMALESS_CARD_DEFS[card]
-    return None, None
+            return card, schemaless_card_defs[card], None
+    return None, None, {"columns": columns}
 
 
 def identify_file(filename):
+    """Return (card_name, info). info is None on match, or dict with 'columns' on no match."""
     records = records_from_file(filename)
-    card, card_def = identify_card(records[0])
-    return card
+    card, _card_def, info = identify_card(records[0])
+    return card, info
 
 
 def save_file_if_valid(file_, data_dir):
@@ -52,7 +65,7 @@ def save_file_if_valid(file_, data_dir):
         tempfilename = os.path.join(tempdir, file_name)
         with open(tempfilename, "wb") as tmpfile:
             tmpfile.write(raw)
-        card = identify_file(tempfilename)
+        card, info = identify_file(tempfilename)
 
         if card:
             if not os.path.exists(upload_dir):
@@ -60,13 +73,18 @@ def save_file_if_valid(file_, data_dir):
             os.replace(tempfilename, os.path.join(upload_dir, file_name))
             return "success", f"{file_name}: {card}"
         else:
-            return "failed", f"{file_name}"
+            columns_msg = f" (columns: {info['columns']})" if info and "columns" in info else ""
+            return "failed", f"{file_name}{columns_msg}"
 
 
 @click.command()
 @click.argument("infile", type=str)
 def _detect(infile):
-    identify_file(infile)
+    card, info = identify_file(infile)
+    if card:
+        click.echo(card)
+    else:
+        click.echo(f"No matching card. Columns: {info['columns'] if info else 'unknown'}")
 
 
 if __name__ == "__main__":

--- a/src/detect.py
+++ b/src/detect.py
@@ -2,6 +2,7 @@ import copy
 import json
 import os
 import tempfile
+from functools import lru_cache
 
 import click
 
@@ -10,6 +11,7 @@ from common import records_from_file
 script_dir = os.path.dirname(os.path.realpath(__file__))
 
 
+@lru_cache(maxsize=1)
 def _load_card_definitions():
     with open(os.path.join(script_dir, "card_definitions.json")) as f:
         definitions = json.load(f)

--- a/src/main.py
+++ b/src/main.py
@@ -4,7 +4,6 @@ import sqlite3
 import webbrowser
 from datetime import date, datetime, timedelta
 
-import dateutil.parser
 import pandas as pd
 import plotly.express as px
 import streamlit as st
@@ -66,18 +65,18 @@ def extend_sql_statement(statement):
 
 
 def add_date_range_widget(df, input_form):
-    min_value = dateutil.parser.parse(df["date"].min())
-    max_value = dateutil.parser.parse(df["date"].max())
+    min_value = parse(df["date"].min())
+    max_value = parse(df["date"].max())
 
     # Initialize from config only if not already in session state
     if "date_range" not in st.session_state:
         min_default = (
-            dateutil.parser.parse(st.session_state.config.get("min_date"))
+            parse(st.session_state.config.get("min_date"))
             if st.session_state.config.get("min_date")
             else min_value
         )
         max_default = (
-            dateutil.parser.parse(st.session_state.config.get("max_date"))
+            parse(st.session_state.config.get("max_date"))
             if st.session_state.config.get("max_date")
             else max_value
         )
@@ -742,8 +741,8 @@ def add_spending_over_time(df):
         return
 
     df = df.set_index(pd.DatetimeIndex(df["date"]))
-    max_date = dateutil.parser.parse(df["date"].max())
-    min_date = dateutil.parser.parse(df["date"].min())
+    max_date = parse(df["date"].max())
+    min_date = parse(df["date"].min())
     n_days = (max_date - min_date).days
     grouping = {"auto": "", "year": "YS", "month": "MS", "week": "W", "day": "D"}
     if n_days >= 730:  # 2+ years
@@ -966,8 +965,8 @@ def main(user):
             resample_codes = {"year": "YS", "month": "MS", "week": "W", "day": "D"}
             period_codes = {"YS": "Y", "MS": "M", "W": "W", "D": "D"}
             if time_bin == "auto":
-                max_date = dateutil.parser.parse(str(df_spending["date"].max()))
-                min_date = dateutil.parser.parse(str(df_spending["date"].min()))
+                max_date = parse(str(df_spending["date"].max()))
+                min_date = parse(str(df_spending["date"].min()))
                 n_days = (max_date - min_date).days
                 if n_days >= 730:
                     resample = "YS"

--- a/src/main.py
+++ b/src/main.py
@@ -1,8 +1,14 @@
 import json
 import os
+import sys
 import sqlite3
 import webbrowser
 from datetime import date, datetime, timedelta
+
+# Ensure src is on path so local modules (parse, pipeline, etc.) resolve when run via streamlit
+_src_dir = os.path.dirname(os.path.abspath(__file__))
+if _src_dir not in sys.path:
+    sys.path.insert(0, _src_dir)
 
 import dateutil.parser
 import pandas as pd
@@ -10,6 +16,13 @@ import plotly.express as px
 import streamlit as st
 from dateutil.parser import parse
 
+from analysis import (
+    flag_high_dining,
+    flag_recurring_in_catchall,
+    identify_frequent_merchants,
+    identify_recurring,
+    monthly_outliers,
+)
 from detect import save_file_if_valid
 from pipeline import run
 from plaidlib import get_transactions
@@ -225,7 +238,9 @@ def add_delete_files_widget(raw_data_dir):
             st.button("Confirm Delete", on_click=delete_files)
 
 
-def save_files_to_disk(files, data_dir):
+def save_files_to_disk(data_dir):
+    # Use session state so we see the files that were in the uploader when the button was clicked
+    files = st.session_state.get("uploaded_files") or []
     success = []
     failed = []
     for file_ in files:
@@ -241,8 +256,10 @@ def save_files_to_disk(files, data_dir):
     if failed:
         status_info = st.error("Failed: " + " ".join(failed))
 
-    # this key increment clears the upload dialog box after clicking upload
+    # clear uploader and session state so the dialog resets
     st.session_state.file_uploader_key += 1
+    if "uploaded_files" in st.session_state:
+        del st.session_state["uploaded_files"]
     clear(streamlit_object=status_info, seconds=2)
 
 
@@ -253,10 +270,12 @@ def add_upload_files_widget(data_dir):
         accept_multiple_files=True,
         key=f"file_uploader_{st.session_state.file_uploader_key}",
     )
+    if files:
+        st.session_state.uploaded_files = files
     st.button(
         "Upload files",
         on_click=save_files_to_disk,
-        kwargs={"files": files, "data_dir": data_dir},
+        kwargs={"data_dir": data_dir},
     )
 
 
@@ -742,7 +761,14 @@ def add_spending_over_time(df):
     else:
         group = "D"
 
-    group_selection = st.select_slider("Time bin", list(grouping))
+    if "time_bin" not in st.session_state:
+        st.session_state.time_bin = "month"
+    group_selection = st.select_slider(
+        "Time bin",
+        options=list(grouping),
+        value=st.session_state.time_bin,
+        key="time_bin",
+    )
     group = group if group_selection == "auto" else grouping[group_selection]
 
     group_titles = {
@@ -844,7 +870,7 @@ def main(user):
 
     # init session state
     if "expand" not in st.session_state:
-        st.session_state.expand = False
+        st.session_state.expand = True
     if "delete_files" not in st.session_state:
         st.session_state.delete_files = set()
     if "file_uploader_key" not in st.session_state:
@@ -882,8 +908,100 @@ def main(user):
     if len(df.index) == 0:
         st.warning("Current selection is empty.")
     else:
-        add_spending_by_category(df)
-        add_spending_over_time(df)
+        # Exclude Payment and Income from spending charts
+        df_spending = df[~df["category"].isin(["Payment", "Income"])]
+        add_spending_by_category(df_spending)
+        add_spending_over_time(df_spending)
+
+        # Analysis section
+        with st.expander("Analysis"):
+            dining_threshold = st.number_input(
+                "Dining threshold",
+                value=100,
+                min_value=1,
+                key="analysis_dining_threshold",
+            )
+            recurring_min = st.number_input(
+                "Min occurrences for recurring",
+                value=2,
+                min_value=2,
+                key="analysis_recurring_min",
+            )
+            high_dining = flag_high_dining(df_spending, threshold=dining_threshold)
+            if not high_dining.empty:
+                st.subheader("High dining (over threshold)")
+                st.dataframe(high_dining, hide_index=True)
+            else:
+                st.caption("No dining over threshold.")
+
+            recurring = identify_recurring(
+                df_spending,
+                min_occurrences=recurring_min,
+            )
+            if not recurring.empty:
+                st.subheader("Recurring expenses / subscriptions (same amount most of the time)")
+                st.dataframe(recurring, hide_index=True)
+            else:
+                st.caption("No recurring expenses identified.")
+
+            frequent = identify_frequent_merchants(
+                df_spending,
+                min_occurrences=recurring_min,
+                exclude_recurring=True,
+            )
+            if not frequent.empty:
+                st.subheader("Frequent merchants (similar schedule, varying amounts)")
+                st.dataframe(frequent, hide_index=True)
+            else:
+                st.caption("No frequent merchants identified.")
+
+            catchall = flag_recurring_in_catchall(
+                df_spending,
+                min_occurrences=recurring_min,
+            )
+            if not catchall.empty:
+                st.subheader("Recurring merchants in Other / Transfer")
+                st.dataframe(catchall, hide_index=True)
+            else:
+                st.caption("No recurring merchants in Other/Transfer.")
+
+            # Use same Time bin as Spending over time for outlier detection
+            time_bin = st.session_state.get("time_bin", "month")
+            resample_codes = {"year": "YS", "month": "MS", "week": "W", "day": "D"}
+            period_codes = {"YS": "Y", "MS": "M", "W": "W", "D": "D"}
+            if time_bin == "auto":
+                max_date = dateutil.parser.parse(str(df_spending["date"].max()))
+                min_date = dateutil.parser.parse(str(df_spending["date"].min()))
+                n_days = (max_date - min_date).days
+                if n_days >= 730:
+                    resample = "YS"
+                elif n_days > 91:
+                    resample = "MS"
+                elif n_days > 31:
+                    resample = "W"
+                else:
+                    resample = "D"
+            else:
+                resample = resample_codes.get(time_bin, "MS")
+            outlier_freq = period_codes.get(resample, "M")
+
+            st.subheader("Outliers by category (time bin: " + time_bin + ")")
+            out_cat = monthly_outliers(
+                df_spending, group_by="category", freq=outlier_freq
+            )
+            if not out_cat.empty:
+                st.dataframe(out_cat, hide_index=True)
+            else:
+                st.caption("No category outliers.")
+
+            st.subheader("Outliers by merchant (time bin: " + time_bin + ")")
+            out_merch = monthly_outliers(
+                df_spending, group_by="merchant", freq=outlier_freq
+            )
+            if not out_merch.empty:
+                st.dataframe(out_merch, hide_index=True)
+            else:
+                st.caption("No merchant outliers.")
 
     if not user:
         try:

--- a/src/main.py
+++ b/src/main.py
@@ -1,14 +1,8 @@
 import json
 import os
-import sys
 import sqlite3
 import webbrowser
 from datetime import date, datetime, timedelta
-
-# Ensure src is on path so local modules (parse, pipeline, etc.) resolve when run via streamlit
-_src_dir = os.path.dirname(os.path.abspath(__file__))
-if _src_dir not in sys.path:
-    sys.path.insert(0, _src_dir)
 
 import dateutil.parser
 import pandas as pd
@@ -939,7 +933,9 @@ def main(user):
                 min_occurrences=recurring_min,
             )
             if not recurring.empty:
-                st.subheader("Recurring expenses / subscriptions (same amount most of the time)")
+                st.subheader(
+                    "Recurring expenses / subscriptions (same amount most of the time)"
+                )
                 st.dataframe(recurring, hide_index=True)
             else:
                 st.caption("No recurring expenses identified.")

--- a/src/parse.py
+++ b/src/parse.py
@@ -4,9 +4,32 @@ import click
 from smart_open import open
 
 from common import get_log
-from detect import identify_card
+from detect import get_schemaless_card_defs, identify_card
 
 log = get_log(__file__)
+
+
+def get_card_from_filename(filename):
+    """Determine card name from a parsed/extracted JSON file (first record)."""
+    with open(filename, "r") as f:
+        first_line = f.readline()
+    record = json.loads(first_line)
+    card, _card_def, info = identify_card(record)
+    if card is None:
+        columns = info.get("columns", []) if info else []
+        raise ValueError(f"No card definition matches {filename}. Columns: {columns}")
+    return card
+
+
+def get_parser(card):
+    """Return a function that parses a record for the given card."""
+    card_defs = get_schemaless_card_defs()
+    card_def = card_defs[card]
+
+    def parser(record):
+        return parse_record(record, card, card_def)
+
+    return parser
 
 
 def parse_record(record, card, card_def):
@@ -46,7 +69,10 @@ def parse(infile, outfile):
 
     log.info(f"Parsing {infile} into {outfile}")
 
-    card, card_def = identify_card(json.loads(open(infile).readline()))
+    card, card_def, no_match_info = identify_card(json.loads(open(infile).readline()))
+    if no_match_info is not None:
+        columns = no_match_info.get("columns", [])
+        raise ValueError(f"No card definition matches this file. Columns: {columns}")
 
     with open(infile, "r") as inf, open(outfile, "w") as outf:
         for line in inf:

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -1,28 +1,12 @@
 import multiprocessing as mp
 import os
-import sys
 import tempfile
-
-# Ensure this package's directory is on path so "parse" resolves to local parse.py
-_script_dir = os.path.dirname(os.path.abspath(__file__))
-if _script_dir not in sys.path:
-    sys.path.insert(0, _script_dir)
 
 from common import get_files, get_log
 from detect import identify_file
 from extract import extract
 from ingest import ingest
-
-try:
-    from parse import parse
-except ModuleNotFoundError as e:
-    if e.name == "parse":
-        raise ModuleNotFoundError(
-            "Local module 'parse' not found. Run from repo root with: "
-            "streamlit run src/main.py (or set PYTHONPATH=src)"
-        ) from e
-    raise
-
+from parse import parse
 from standardize import standardize
 from utils import make_dirs
 

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -1,12 +1,28 @@
 import multiprocessing as mp
 import os
+import sys
 import tempfile
+
+# Ensure this package's directory is on path so "parse" resolves to local parse.py
+_script_dir = os.path.dirname(os.path.abspath(__file__))
+if _script_dir not in sys.path:
+    sys.path.insert(0, _script_dir)
 
 from common import get_files, get_log
 from detect import identify_file
 from extract import extract
 from ingest import ingest
-from parse import parse
+
+try:
+    from parse import parse
+except ModuleNotFoundError as e:
+    if e.name == "parse":
+        raise ModuleNotFoundError(
+            "Local module 'parse' not found. Run from repo root with: "
+            "streamlit run src/main.py (or set PYTHONPATH=src)"
+        ) from e
+    raise
+
 from standardize import standardize
 from utils import make_dirs
 
@@ -23,7 +39,7 @@ def get_pipeline_files(raw_dir, extracted_dir, parsed_dir, standardized_dir):
     intermediate steps pf the pipeline
     """
     suffix = ".json"
-    for raw_file in [f for f in get_files(raw_dir) if identify_file(f)]:
+    for raw_file in [f for f in get_files(raw_dir) if identify_file(f)[0]]:
         filestem = get_filename_without_extension(raw_file)
         extracted_file = os.path.join(extracted_dir, filestem + suffix)
         parsed_file = os.path.join(parsed_dir, filestem + suffix)

--- a/src/record.py
+++ b/src/record.py
@@ -61,12 +61,14 @@ class Card(object):
 
     @property
     def record_is_payment(self):
-        """Mask for payments (as opposed to expenses)."""
-        return (
+        """Mask for payments and income (excluded from spending charts)."""
+        description_match = (
             self.records["description"]
             .str.lower()
             .str.contains("autopay|thank you|payment")
         )
+        category_excluded = self.records["category"].isin(["Payment", "Income"])
+        return description_match | category_excluded
 
     @property
     def monthly_spending(self):

--- a/src/standardize.py
+++ b/src/standardize.py
@@ -122,7 +122,7 @@ default_description_map = {
     "payment - web": "Payment",
     "AMERICAN EXPRESS ACH PMT": "Payment",
     "Payment to Chase card": "Payment",
-    "CRCARDPMT": "Payment"
+    "CRCARDPMT": "Payment",
 }
 
 

--- a/src/standardize.py
+++ b/src/standardize.py
@@ -66,8 +66,13 @@ default_category_map = {
     "Home": "Shopping",
     # Examples: tj, whole foods
     "Groceries": "Groceries",
+    # Bank transaction types
+    "ACCT_XFER": "Transfer",
 }
 
+
+# Credit card payment patterns (applied last so they are not overwritten by other rules)
+PAYMENT_DESCRIPTION_PATTERNS = ("payment thank you", "autopay payment", "payment - web")
 
 default_description_map = {
     "LYFT": "Rideshare",
@@ -82,6 +87,42 @@ default_description_map = {
     "Sanador": "Health",
     "CAPEAIR": "Travel",
     "EATS": "Dining",
+    "HBO": "Entertainment",
+    "Max": "Entertainment",
+    "IRS": "Taxes",
+    "CITY OF MEDFORD": "Taxes",
+    "COMM OF MASS": "Taxes",
+    "zelle payment from": "Income",
+    "real time payment credit recd": "Income",
+    "remote online deposit": "Income",
+    "ppd id": "Income",
+    "payroll": "Income",
+    "zelle payment": "Transfer",
+    "edi pymnts": "Transfer",
+    "venmo": "Transfer",
+    "online transfer": "Transfer",
+    # Bills
+    "mtg": "Bills",
+    "mortgage": "Bills",
+    "grid": "Bills",
+    "paymentrec": "Bills",
+    # Car
+    "ach rtl": "Car",
+    # Services
+    "barber": "Services",
+    "haircut": "Services",
+    # Health / Travel / Shopping
+    "animal hosp": "Health",
+    "vfs": "Travel",
+    "namecheap": "Bills",
+    "ebay": "Shopping",
+    # Credit card payments last so they always win
+    "payment thank you": "Payment",
+    "autopay payment": "Payment",
+    "payment - web": "Payment",
+    "AMERICAN EXPRESS ACH PMT": "Payment",
+    "Payment to Chase card": "Payment",
+    "CRCARDPMT": "Payment"
 }
 
 
@@ -93,23 +134,31 @@ def standardizer(record, rules):
     record["date"] = parse(record["date"]).isoformat()
     record["new_category"] = "Other"
 
+    raw_category = record.get("category") or ""
+    raw_category_lower = raw_category.lower() if isinstance(raw_category, str) else ""
     for rule, new_category in list(default_category_map.items()) + list(
         rules.get("category", {}).items()
     ):
-        if rule.lower() in record["category"].lower():
+        if rule.lower() in raw_category_lower:
             record["new_category"] = new_category
 
+    description_lower = (record.get("description") or "").lower()
     for rule, new_category in list(default_description_map.items()) + list(
         rules.get("description", {}).items()
     ):
-        if rule.lower() in record["description"].lower():
+        if rule.lower() in description_lower:
             record["new_category"] = new_category
 
     if (
-        "venmo" in record["description"].lower()
-        and "mitfcu" in record["source_file"].lower()
+        "venmo" in description_lower
+        and "mitfcu" in (record.get("source_file") or "").lower()
     ):
         record["new_category"] = "Transfer"
+
+    # Credit card payments: ensure they are never overwritten by Other
+    if any(p in description_lower for p in PAYMENT_DESCRIPTION_PATTERNS):
+        record["new_category"] = "Payment"
+
     record["old_category"] = record["category"]
     record["category"] = record["new_category"]
     record.pop("new_category")

--- a/src/standardize.py
+++ b/src/standardize.py
@@ -71,9 +71,6 @@ default_category_map = {
 }
 
 
-# Credit card payment patterns (applied last so they are not overwritten by other rules)
-PAYMENT_DESCRIPTION_PATTERNS = ("payment thank you", "autopay payment", "payment - web")
-
 default_description_map = {
     "LYFT": "Rideshare",
     "UBER": "Rideshare",
@@ -125,6 +122,11 @@ default_description_map = {
     "CRCARDPMT": "Payment",
 }
 
+# Keys in default_description_map that map to Payment; re-applied last so user rules cannot override.
+PAYMENT_DESCRIPTION_PATTERNS = tuple(
+    k for k, v in default_description_map.items() if v == "Payment"
+)
+
 
 def get_default_categories():
     return set(default_description_map.values()) | set(default_category_map.values())
@@ -155,7 +157,7 @@ def standardizer(record, rules):
     ):
         record["new_category"] = "Transfer"
 
-    # Credit card payments: ensure they are never overwritten by Other
+    # Credit card payments: user description rules run after defaults, so re-apply so they always win.
     if any(p in description_lower for p in PAYMENT_DESCRIPTION_PATTERNS):
         record["new_category"] = "Payment"
 

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -96,4 +96,4 @@ def test_monthly_outliers_by_category():
     assert not out.empty
     high = out[out["is_high_outlier"]]
     assert len(high) >= 1
-    assert high.iloc[0]["monthly_amount"] == 500.0
+    assert high.iloc[0]["period_amount"] == 500.0

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -20,12 +20,14 @@ def test_normalize_merchant():
 
 def test_identify_recurring():
     # 3 transactions ~30 days apart, same amount -> recurring (subscription)
-    df = pd.DataFrame({
-        "date": ["2024-01-01", "2024-02-01", "2024-03-01"],
-        "description": ["NETFLIX 123", "NETFLIX 456", "NETFLIX 789"],
-        "category": ["Entertainment"] * 3,
-        "amount": [15.0, 15.0, 15.0],
-    })
+    df = pd.DataFrame(
+        {
+            "date": ["2024-01-01", "2024-02-01", "2024-03-01"],
+            "description": ["NETFLIX 123", "NETFLIX 456", "NETFLIX 789"],
+            "category": ["Entertainment"] * 3,
+            "amount": [15.0, 15.0, 15.0],
+        }
+    )
     out = identify_recurring(df, min_occurrences=3, interval_tolerance_days=7)
     assert len(out) == 1
     assert out.iloc[0]["transaction_count"] == 3
@@ -34,26 +36,32 @@ def test_identify_recurring():
 
 def test_identify_frequent_merchants():
     # 3 transactions ~30 days apart but varying amounts -> frequent, not recurring
-    df = pd.DataFrame({
-        "date": ["2024-01-01", "2024-02-01", "2024-03-01"],
-        "description": ["COFFEE SHOP A", "COFFEE SHOP B", "COFFEE SHOP C"],
-        "category": ["Dining"] * 3,
-        "amount": [5.0, 12.0, 8.0],
-    })
+    df = pd.DataFrame(
+        {
+            "date": ["2024-01-01", "2024-02-01", "2024-03-01"],
+            "description": ["COFFEE SHOP A", "COFFEE SHOP B", "COFFEE SHOP C"],
+            "category": ["Dining"] * 3,
+            "amount": [5.0, 12.0, 8.0],
+        }
+    )
     recurring = identify_recurring(df, min_occurrences=3, interval_tolerance_days=7)
-    frequent = identify_frequent_merchants(df, min_occurrences=3, exclude_recurring=True)
+    frequent = identify_frequent_merchants(
+        df, min_occurrences=3, exclude_recurring=True
+    )
     assert len(recurring) == 0
     assert len(frequent) == 1
     assert frequent.iloc[0]["transaction_count"] == 3
 
 
 def test_flag_high_dining():
-    df = pd.DataFrame({
-        "date": ["2024-01-01", "2024-01-02"],
-        "description": ["Fancy Restaurant", "Coffee Shop"],
-        "category": ["Dining", "Dining"],
-        "amount": [150.0, 8.0],
-    })
+    df = pd.DataFrame(
+        {
+            "date": ["2024-01-01", "2024-01-02"],
+            "description": ["Fancy Restaurant", "Coffee Shop"],
+            "category": ["Dining", "Dining"],
+            "amount": [150.0, 8.0],
+        }
+    )
     out = flag_high_dining(df, threshold=100)
     assert len(out) == 1
     assert out.iloc[0]["amount"] == 150.0
@@ -61,12 +69,14 @@ def test_flag_high_dining():
 
 
 def test_flag_recurring_in_catchall():
-    df = pd.DataFrame({
-        "date": ["2024-01-01", "2024-02-01"],
-        "description": ["SOME MERCHANT 123", "SOME MERCHANT 456"],
-        "category": ["Other", "Other"],
-        "amount": [10.0, 10.0],
-    })
+    df = pd.DataFrame(
+        {
+            "date": ["2024-01-01", "2024-02-01"],
+            "description": ["SOME MERCHANT 123", "SOME MERCHANT 456"],
+            "category": ["Other", "Other"],
+            "amount": [10.0, 10.0],
+        }
+    )
     out = flag_recurring_in_catchall(df, min_occurrences=2)
     assert len(out) >= 1
     assert out.iloc[0]["transaction_count"] == 2
@@ -74,12 +84,14 @@ def test_flag_recurring_in_catchall():
 
 def test_monthly_outliers_by_category():
     # One month much higher than others
-    df = pd.DataFrame({
-        "date": ["2024-01-15", "2024-02-15", "2024-03-15", "2024-04-15"],
-        "description": ["A", "A", "A", "A"],
-        "category": ["Shopping", "Shopping", "Shopping", "Shopping"],
-        "amount": [100.0, 100.0, 100.0, 500.0],
-    })
+    df = pd.DataFrame(
+        {
+            "date": ["2024-01-15", "2024-02-15", "2024-03-15", "2024-04-15"],
+            "description": ["A", "A", "A", "A"],
+            "category": ["Shopping", "Shopping", "Shopping", "Shopping"],
+            "amount": [100.0, 100.0, 100.0, 500.0],
+        }
+    )
     out = monthly_outliers(df, group_by="category", method="iqr", k=1.5)
     assert not out.empty
     high = out[out["is_high_outlier"]]

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,0 +1,87 @@
+import pandas as pd
+
+from analysis import (
+    flag_high_dining,
+    flag_recurring_in_catchall,
+    identify_frequent_merchants,
+    identify_recurring,
+    monthly_outliers,
+    normalize_merchant,
+)
+
+
+def test_normalize_merchant():
+    s = pd.Series(["NETFLIX 12345", "  Lyft   *RIDE  ", "Trader Joe's"])
+    out = normalize_merchant(s)
+    assert out.iloc[0] == "netflix"
+    assert "lyft" in out.iloc[1]
+    assert out.iloc[2].startswith("trader")
+
+
+def test_identify_recurring():
+    # 3 transactions ~30 days apart, same amount -> recurring (subscription)
+    df = pd.DataFrame({
+        "date": ["2024-01-01", "2024-02-01", "2024-03-01"],
+        "description": ["NETFLIX 123", "NETFLIX 456", "NETFLIX 789"],
+        "category": ["Entertainment"] * 3,
+        "amount": [15.0, 15.0, 15.0],
+    })
+    out = identify_recurring(df, min_occurrences=3, interval_tolerance_days=7)
+    assert len(out) == 1
+    assert out.iloc[0]["transaction_count"] == 3
+    assert out.iloc[0]["mean_interval_days"] >= 25
+
+
+def test_identify_frequent_merchants():
+    # 3 transactions ~30 days apart but varying amounts -> frequent, not recurring
+    df = pd.DataFrame({
+        "date": ["2024-01-01", "2024-02-01", "2024-03-01"],
+        "description": ["COFFEE SHOP A", "COFFEE SHOP B", "COFFEE SHOP C"],
+        "category": ["Dining"] * 3,
+        "amount": [5.0, 12.0, 8.0],
+    })
+    recurring = identify_recurring(df, min_occurrences=3, interval_tolerance_days=7)
+    frequent = identify_frequent_merchants(df, min_occurrences=3, exclude_recurring=True)
+    assert len(recurring) == 0
+    assert len(frequent) == 1
+    assert frequent.iloc[0]["transaction_count"] == 3
+
+
+def test_flag_high_dining():
+    df = pd.DataFrame({
+        "date": ["2024-01-01", "2024-01-02"],
+        "description": ["Fancy Restaurant", "Coffee Shop"],
+        "category": ["Dining", "Dining"],
+        "amount": [150.0, 8.0],
+    })
+    out = flag_high_dining(df, threshold=100)
+    assert len(out) == 1
+    assert out.iloc[0]["amount"] == 150.0
+    assert out.iloc[0]["category"] == "Dining"
+
+
+def test_flag_recurring_in_catchall():
+    df = pd.DataFrame({
+        "date": ["2024-01-01", "2024-02-01"],
+        "description": ["SOME MERCHANT 123", "SOME MERCHANT 456"],
+        "category": ["Other", "Other"],
+        "amount": [10.0, 10.0],
+    })
+    out = flag_recurring_in_catchall(df, min_occurrences=2)
+    assert len(out) >= 1
+    assert out.iloc[0]["transaction_count"] == 2
+
+
+def test_monthly_outliers_by_category():
+    # One month much higher than others
+    df = pd.DataFrame({
+        "date": ["2024-01-15", "2024-02-15", "2024-03-15", "2024-04-15"],
+        "description": ["A", "A", "A", "A"],
+        "category": ["Shopping", "Shopping", "Shopping", "Shopping"],
+        "amount": [100.0, 100.0, 100.0, 500.0],
+    })
+    out = monthly_outliers(df, group_by="category", method="iqr", k=1.5)
+    assert not out.empty
+    high = out[out["is_high_outlier"]]
+    assert len(high) >= 1
+    assert high.iloc[0]["monthly_amount"] == 500.0

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -106,9 +106,10 @@ def test_save_file_if_valid_invalid():
             _f.write(unknown_string)
         file_object = open(input_, "rb")
 
-        expected = "failed", f"{filename}"
-        actual = save_file_if_valid(file_object, data_dir)
-        assert actual == expected
+        status, msg = save_file_if_valid(file_object, data_dir)
+        assert status == "failed"
+        assert filename in msg
+        assert "columns:" in msg
 
         with pytest.raises(FileNotFoundError):
             open(os.path.join(data_dir, "raw", filename), "r")

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -1,5 +1,7 @@
-from detect import SCHEMALESS_CARD_DEFS as CARD_DEFINITIONS
+from detect import get_schemaless_card_defs
 from detect import identify_card
+
+CARD_DEFS = get_schemaless_card_defs()
 
 
 def test_detect_amex():
@@ -16,8 +18,8 @@ def test_detect_amex():
         "Reference": "'123'",
         "Category": "Merchandise & Supplies-Groceries",
     }
-    expected = "amex", CARD_DEFINITIONS["amex"]
-    assert identify_card(input_) == expected
+    card, card_def, info = identify_card(input_)
+    assert card == "amex" and card_def == CARD_DEFS["amex"] and info is None
 
 
 def test_detect_chase():
@@ -30,8 +32,8 @@ def test_detect_chase():
         "Amount": -123,
         "Memo": "",
     }
-    expected = "chase", CARD_DEFINITIONS["chase"]
-    assert identify_card(input_) == expected
+    card, card_def, info = identify_card(input_)
+    assert card == "chase" and card_def == CARD_DEFS["chase"] and info is None
 
 
 def test_detect_capital_one():
@@ -44,8 +46,8 @@ def test_detect_capital_one():
         "Debit": 123,
         "Credit": None,
     }
-    expected = "capital_one", CARD_DEFINITIONS["capital_one"]
-    assert identify_card(input_) == expected
+    card, card_def, info = identify_card(input_)
+    assert card == "capital_one" and card_def == CARD_DEFS["capital_one"] and info is None
 
 
 def test_detect_usbank():
@@ -56,5 +58,12 @@ def test_detect_usbank():
         "Memo": "WEB AUTOMTC; ; ; ; ; ",
         "Amount": 123.45,
     }
-    expected = "usbank", CARD_DEFINITIONS["usbank"]
-    assert identify_card(input_) == expected
+    card, card_def, info = identify_card(input_)
+    assert card == "usbank" and card_def == CARD_DEFS["usbank"] and info is None
+
+
+def test_detect_no_match_returns_columns():
+    input_ = {"Foo": 1, "Bar": 2}
+    card, card_def, info = identify_card(input_)
+    assert card is None and card_def is None
+    assert info is not None and info.get("columns") == ["Foo", "Bar"]

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -1,5 +1,4 @@
-from detect import get_schemaless_card_defs
-from detect import identify_card
+from detect import get_schemaless_card_defs, identify_card
 
 CARD_DEFS = get_schemaless_card_defs()
 
@@ -47,7 +46,9 @@ def test_detect_capital_one():
         "Credit": None,
     }
     card, card_def, info = identify_card(input_)
-    assert card == "capital_one" and card_def == CARD_DEFS["capital_one"] and info is None
+    assert (
+        card == "capital_one" and card_def == CARD_DEFS["capital_one"] and info is None
+    )
 
 
 def test_detect_usbank():

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -25,7 +25,7 @@ def test_parse():
         "source": "amex",
         "source_file": "amex.csv",
     }
-    card, card_def = identify_card(input_)
+    card, card_def, _ = identify_card(input_)
     assert parse_record(input_, card, card_def) == expected
 
     input_ = {
@@ -46,7 +46,7 @@ def test_parse():
         "source": "capital_one",
         "source_file": "capital_one.csv",
     }
-    card, card_def = identify_card(input_)
+    card, card_def, _ = identify_card(input_)
     assert parse_record(input_, card, card_def) == expected
 
     input_ = {
@@ -67,7 +67,7 @@ def test_parse():
         "source": "chase",
         "source_file": "chase.csv",
     }
-    card, card_def = identify_card(input_)
+    card, card_def, _ = identify_card(input_)
     assert parse_record(input_, card, card_def) == expected
 
     input_ = {
@@ -86,5 +86,5 @@ def test_parse():
         "source": "usbank",
         "source_file": "usbank.csv",
     }
-    card, card_def = identify_card(input_)
+    card, card_def, _ = identify_card(input_)
     assert parse_record(input_, card, card_def) == expected

--- a/tests/test_standardize.py
+++ b/tests/test_standardize.py
@@ -82,6 +82,9 @@ def test_get_default_categories():
         "Dining",
         "Services",
         "Payment",
+        "Transfer",
+        "Income",
+        "Taxes",
     }
 
     assert actual == expected


### PR DESCRIPTION
## Expenses: Chase/Amex support, analysis module, and categorization

- **Card definitions:** Add couple more card definitions to `card_definitions.json`; fix detection when CSV has a trailing empty column.
- **Detection:** `identify_card` returns `(card, card_def, info)`; on no match `info` includes `columns` so upload failures show which columns were seen. Card definitions are loaded on each use so new definitions apply without restart. Upload flow uses session state for the file list.
- **Standardization:** Add Income category and exclude it (with Payment) from spending charts. Add description/category rules for payments, transfers, bills, car, services, health, travel; use generic slugs (e.g. `ppd id`, `ach rtl`, `mtg`, `barber`) instead of merchant names. Ensure credit-card payment descriptions are always categorized as Payment.
- **Analysis module (`analysis.py`):** Recurring expenses (same amount in ≥80% of transactions) vs frequent merchants (similar schedule, varying amounts); high-dining flag (configurable threshold); recurring merchants in Other/Transfer; monthly (or configurable period) outliers by category and by merchant. Analysis section in the UI uses the same Time bin as "Spending over time."
- **Misc:** `parse.py` adds `get_card_from_filename` and `get_parser` for `record.py`. Path handling and imports fixed so the app runs reliably (e.g. `streamlit run src/main.py`). Tests updated for new return shapes and analysis behavior.